### PR TITLE
Fix return type for Connection::connect()

### DIFF
--- a/src/Decorator/JaegerConnectionDecorator.php
+++ b/src/Decorator/JaegerConnectionDecorator.php
@@ -26,10 +26,10 @@ class JaegerConnectionDecorator extends AbstractConnectionDecorator
         parent::__construct($connection);
     }
 
-    public function connect()
+    public function connect(): bool
     {
         if ($this->isConnected()) {
-            return;
+            return false;
         }
         $span = $this->tracer
             ->start('dbal.connect')
@@ -38,7 +38,7 @@ class JaegerConnectionDecorator extends AbstractConnectionDecorator
             ->addTag(new DbalAutoCommitTag($this->isAutoCommit()))
             ->addTag(new DbalNestingLevelTag($this->getTransactionNestingLevel()));
         try {
-            parent::connect();
+            return parent::connect();
         } catch (\Exception $e) {
             $span->addTag(new DbalErrorCodeTag($e->getCode()))
                 ->addTag(new ErrorTag());


### PR DESCRIPTION
Method must return `bool` according to phpdoc in `Doctrine\DBAL\Connection::connect()`
> @return bool TRUE if the connection was successfully established, FALSE if the connection is already open.

Missed return bool leads to type error while this package used with `doctrine/migrations:^2`