### PR TITLE
Fix return type for Connection::connect() in wrapper

### DIFF
--- a/src/Wrapper/JaegerConnectionWrapper.php
+++ b/src/Wrapper/JaegerConnectionWrapper.php
@@ -33,11 +33,11 @@ class JaegerConnectionWrapper extends Connection
     public function connect()
     {
         if ($this->isConnected()) {
-            return;
+            return false;
         }
         $span = $this->tracer->start('dbal.connect');
         try {
-            parent::connect();
+            return parent::connect();
         } catch (\Exception $e) {
             $span->addTag(new DbalErrorCodeTag($e->getCode()))
                 ->addTag(new ErrorTag());


### PR DESCRIPTION
Method must return bool according to phpdoc in Doctrine\DBAL\Connection::connect()

> `@`return bool TRUE if the connection was successfully established, FALSE if the connection is already open.

Missed return bool leads to type error while this package used with doctrine/migrations:^2