### PR TITLE
Prepared statement execute call tracing.

### DIFF
--- a/src/Wrapper/JaegerStatementWrapper.php
+++ b/src/Wrapper/JaegerStatementWrapper.php
@@ -1,0 +1,43 @@
+<?php
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Jaeger\Wrapper;
+
+use Doctrine\DBAL\Jaeger\Tag\DbalErrorCodeTag;
+use Doctrine\DBAL\Statement;
+use Jaeger\Tag\DbStatementTag;
+use Jaeger\Tag\ErrorTag;
+use Jaeger\Tracer\TracerInterface;
+
+class JaegerStatementWrapper extends Statement
+{
+    /**
+     * @var TracerInterface $tracer
+     */
+    private $tracer;
+
+    public function setTracer(TracerInterface $tracer)
+    {
+        $this->tracer = $tracer;
+
+        return $this;
+    }
+
+    public function execute($params = null)
+    {
+        $span = $this->tracer
+            ->start('dbal.prepare.execute')
+            ->addTag(new DbStatementTag($this->sql));
+
+        try {
+            return parent::execute($params);
+        } catch (\Exception $e) {
+            $span->addTag(new DbalErrorCodeTag($e->getCode()))
+                ->addTag(new ErrorTag());
+
+            throw $e;
+        } finally {
+            $this->tracer->finish($span);
+        }
+    }
+}


### PR DESCRIPTION
Sometimes Doctrine\DBAL\Statement::execute() call can take a long time (because of locks for example).

This PR adds the ability to create a separate span on execute() call.

![Selection_850](https://user-images.githubusercontent.com/881794/110642471-baee9f00-81bb-11eb-9068-e2a1baf12e34.png)
